### PR TITLE
fix(progress): make label color follow the theme

### DIFF
--- a/src/components/progress/progress.css
+++ b/src/components/progress/progress.css
@@ -5,7 +5,8 @@
     --bl-progress-color: var(--bl-clr-gray-700);
     --bl-progress-border-radius: var(--bl-border-radius-full);
     --bl-progress-animation-duration: 1.5s;
-    --bl-progress-label-color: #fff;
+    --bl-progress-label-color: var(--bl-clr-gray-100);
+    --bl-progress-stripe-color: rgba(255, 255, 255, 0.15);
 
     position: relative;
     width: 100%;
@@ -56,22 +57,27 @@
   /* Color variants */
   .progress-primary {
     --bl-progress-color: var(--bl-clr-primary-600);
+    --bl-progress-label-color: #fff;
   }
 
   .progress-success {
     --bl-progress-color: var(--bl-clr-green-600);
+    --bl-progress-label-color: #fff;
   }
 
   .progress-danger {
     --bl-progress-color: var(--bl-clr-red-600);
+    --bl-progress-label-color: #fff;
   }
 
   .progress-warning {
     --bl-progress-color: var(--bl-clr-orange-600);
+    --bl-progress-label-color: #fff;
   }
 
   .progress-info {
     --bl-progress-color: var(--bl-clr-blue-600);
+    --bl-progress-label-color: #fff;
   }
 
   /* Striped variant */
@@ -79,11 +85,11 @@
     .progress-bar {
       background-image: linear-gradient(
         45deg,
-        rgba(255, 255, 255, 0.15) 25%,
+        var(--bl-progress-stripe-color) 25%,
         transparent 25%,
         transparent 50%,
-        rgba(255, 255, 255, 0.15) 50%,
-        rgba(255, 255, 255, 0.15) 75%,
+        var(--bl-progress-stripe-color) 50%,
+        var(--bl-progress-stripe-color) 75%,
         transparent 75%,
         transparent
       );
@@ -128,7 +134,20 @@
   .dark {
     .progress {
       --bl-progress-bg: var(--bl-clr-gray-700);
-      --bl-progress-color: var(--bl-clr-primary-600);
+      --bl-progress-color: var(--bl-clr-gray-100);
+      --bl-progress-label-color: var(--bl-clr-gray-900);
+      --bl-progress-stripe-color: rgba(0, 0, 0, 0.15);
+    }
+
+    /* Color variants keep their light-theme fill, so the label stays white.
+       Repeated here to outrank the `.dark .progress` neutral defaults. */
+    .progress-primary,
+    .progress-success,
+    .progress-danger,
+    .progress-warning,
+    .progress-info {
+      --bl-progress-label-color: #fff;
+      --bl-progress-stripe-color: rgba(255, 255, 255, 0.15);
     }
 
     .progress-primary {
@@ -149,10 +168,6 @@
 
     .progress-info {
       --bl-progress-color: var(--bl-clr-blue-600);
-    }
-
-    .progress-label {
-      text-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
     }
   }
 


### PR DESCRIPTION
Closes #103

## Problem

`.progress-label` had its color hardcoded to `#fff`, so it could never adapt to the fill behind it.

This was masked in dark theme by a second issue: `.dark .progress` reset `--bl-progress-color` to `--bl-clr-primary-600`, so the **neutral** (no variant) progress bar silently turned blue in dark mode instead of inverting the way every other neutral surface does. As soon as the neutral bar takes a light fill in dark theme — which is what the badge component already does (`gray-900`/`gray-100` → `gray-100`/`gray-900`) — the white label becomes unreadable.

## Changes

- `--bl-progress-label-color` now defaults to `var(--bl-clr-gray-100)` and is set per variant instead of being a single hardcoded white.
- Dark theme neutral bar inverts (`gray-100` fill, `gray-900` label) rather than falling back to the primary color.
- Color variants (`primary`, `success`, `danger`, `warning`, `info`) keep a white label in both themes. They are re-listed in the `.dark` block because `.dark .progress` (0,2,0) outranks `.progress-primary` (0,1,0).
- Stripes moved to a `--bl-progress-stripe-color` token so they stay visible on the light neutral fill in dark theme (white stripes on a light bar would vanish).
- Dropped the `.dark .progress-label { text-shadow }` contrast band-aid — no longer needed now that the colors pair correctly.

## Verification

Rendered the built `dist/bloum.min.css` in Chromium (Playwright) across all variants, both themes, plain and striped. All labels are legible on their fill in both themes; light theme is visually unchanged apart from the label going from `#fff` to `gray-100` on the neutral bar.

## Note

The issue had no body, so I worked from the title. I could not get an unreadable white label out of `main` as-is — the dark neutral bar renders blue there, and white on blue reads fine. My read is that the blue fallback is itself the defect and the report is about the neutral bar's intended light fill. If you actually hit this on a different surface, say so and I'll re-target the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)