### PR TITLE
refactor(menu)!: rename data-dropdown-toggle to data-menu-toggle

### DIFF
--- a/src/components/breadcrumb/breadcrumb.stories.ts
+++ b/src/components/breadcrumb/breadcrumb.stories.ts
@@ -43,7 +43,7 @@ export const BreadcrumbWithMenu: Story = {
     <li class="breadcrumb-item breadcrumb-separator"><i class="fas fa-angle-right"></i></li>
     <li class="breadcrumb-item">
       <div class="dropdown">
-        <button data-dropdown-toggle class="flex items-center gap-2">Library<i class="fas fa-angle-down text-xs"></i></button>
+        <button data-menu-toggle class="flex items-center gap-2">Library<i class="fas fa-angle-down text-xs"></i></button>
         <div class="menu" id="menu">
           <div class="menu-group">
             <a href="#" class="menu-item">New File</a>

--- a/src/components/menu/menu.stories.ts
+++ b/src/components/menu/menu.stories.ts
@@ -12,7 +12,7 @@ export const Menu: Story = {
   render: () => {
     return `
 <div class="dropdown">
-  <button class="btn btn-outline" data-dropdown-toggle>Options</button>
+  <button class="btn btn-outline" data-menu-toggle>Options</button>
   <div class="menu" id="menu">
     <div class="menu-group">
       <div class="menu-label">My Account</div>
@@ -85,7 +85,7 @@ export const MenuWithIcons: Story = {
   render: () => {
     return `
 <div class="dropdown" style="margin-left: 8rem">
-  <button class="btn" data-dropdown-toggle><i class="fas fa-bars"></i> Options</button>
+  <button class="btn" data-menu-toggle><i class="fas fa-bars"></i> Options</button>
   <div class="menu">
     <a href="#" class="menu-item"><i class="fas fa-file fa-fw"></i> New File</a>
     <a href="#" class="menu-item"><i class="fas fa-folder-open fa-fw"></i> Open...</a>
@@ -103,7 +103,7 @@ export const MenuWithDanger: Story = {
   render: () => {
     return `
 <div class="dropdown">
-  <button class="btn" data-dropdown-toggle>Click to open the menu</button>
+  <button class="btn" data-menu-toggle>Click to open the menu</button>
   <div class="menu">
     <a href="#" class="menu-item">New File</a>
     <a href="#" class="menu-item">Open File...</a>
@@ -120,7 +120,7 @@ export const MenuWithCheckbox: Story = {
   render: () => {
     return `
 <div class="dropdown">
-  <button class="btn" data-dropdown-toggle><i class="fas fa-cog"></i>Features</button>
+  <button class="btn" data-menu-toggle><i class="fas fa-cog"></i>Features</button>
   <div class="menu">
     <label class="menu-item"><input type="checkbox" class="input-check">Feature 1</label>
     <label class="menu-item"><input type="checkbox" class="input-check">Feature 2</label>

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -365,9 +365,7 @@ export function initMenus() {
       return;
     }
 
-    const trigger = dropdown.querySelector<HTMLElement>(
-      "[data-dropdown-toggle]",
-    );
+    const trigger = dropdown.querySelector<HTMLElement>("[data-menu-toggle]");
     if (!trigger) {
       return;
     }

--- a/src/components/navbar/navbar.stories.ts
+++ b/src/components/navbar/navbar.stories.ts
@@ -31,7 +31,7 @@ export const Navbar: Story = {
         <a class="nav-link" href="#">Page 3</a>
       </div>
       <div class="nav-item dropdown">
-        <a class="nav-link hstack gap-2" href="#" data-dropdown-toggle>
+        <a class="nav-link hstack gap-2" href="#" data-menu-toggle>
           Dropdown <i class="fas fa-chevron-down"></i>
         </a>
         <div class="menu">
@@ -48,7 +48,7 @@ export const Navbar: Story = {
     </div>
     <div class="nav-items">
       <div class="nav-item dropdown">
-        <div class="avatar cursor-pointer" data-dropdown-toggle>
+        <div class="avatar cursor-pointer" data-menu-toggle>
           <span class="avatar-initials">JD</span>
         </div>
         <div class="menu">

--- a/src/components/sidebar/sidebar.stories.ts
+++ b/src/components/sidebar/sidebar.stories.ts
@@ -373,7 +373,7 @@ export const WithCollapsible: Story = {
             </div>
           </div>
           <div class="dropdown">
-            <button class="btn btn-icon btn-ghost btn-sm" data-dropdown-toggle>
+            <button class="btn btn-icon btn-ghost btn-sm" data-menu-toggle>
               <i class="fa-solid fa-ellipsis-vertical"></i>
             </button>
             <div class="menu">
@@ -508,7 +508,7 @@ export const WithCollapsible: Story = {
           <div class="flex justify-between items-center">
             <h3 class="text-light text-sm uppercase tracking-wide">Sales</h3>
             <div class="dropdown">
-              <a href="#" class="text-light" data-dropdown-toggle>Last 7 days <i class="fas fa-chevron-down"></i></a>
+              <a href="#" class="text-light" data-menu-toggle>Last 7 days <i class="fas fa-chevron-down"></i></a>
               <div class="menu">
                 <button class="menu-item">Last 7 days</button>
                 <button class="menu-item">Last month</button>

--- a/website/src/pages/components.astro
+++ b/website/src/pages/components.astro
@@ -1138,7 +1138,7 @@ import FontSelector from "../components/font-selector.astro";
         <!-- Menu -->
         <Demo title="Menu">
           <div class="dropdown">
-            <button class="btn btn-outline" data-dropdown-toggle>Options</button
+            <button class="btn btn-outline" data-menu-toggle>Options</button
             >
             <div class="menu" id="menu">
               <div class="menu-group">
@@ -1256,7 +1256,7 @@ import FontSelector from "../components/font-selector.astro";
                     <a
                       class="nav-link hstack gap-2"
                       href="#"
-                      data-dropdown-toggle
+                      data-menu-toggle
                     >
                       More <i class="fas fa-chevron-down"></i>
                     </a>
@@ -1274,7 +1274,7 @@ import FontSelector from "../components/font-selector.astro";
                 </div>
                 <div class="nav-items">
                   <div class="nav-item dropdown">
-                    <div class="avatar cursor-pointer" data-dropdown-toggle>
+                    <div class="avatar cursor-pointer" data-menu-toggle>
                       <span class="avatar-initials">JD</span>
                     </div>
                     <div class="menu">

--- a/website/src/pages/templates/sidebar-dashboard.astro
+++ b/website/src/pages/templates/sidebar-dashboard.astro
@@ -180,7 +180,7 @@ import Template from "../../layouts/template.astro";
             <div class="dropdown">
               <button
                 class="btn btn-icon btn-ghost btn-sm"
-                data-dropdown-toggle
+                data-menu-toggle
               >
                 <i class="fa-solid fa-ellipsis-vertical"></i>
               </button>
@@ -359,7 +359,7 @@ import Template from "../../layouts/template.astro";
               <div class="dropdown">
                 <button
                   class="btn btn-sm btn-icon btn-ghost"
-                  data-dropdown-toggle
+                  data-menu-toggle
                   aria-label="More options"
                 >
                   <i class="fas fa-ellipsis-vertical"></i>


### PR DESCRIPTION
Closes #99

Renames the menu trigger attribute `data-dropdown-toggle` → `data-menu-toggle` so it matches the component name.

## Changes

- `src/components/menu/menu.ts` — the `initMenus()` trigger selector
- Stories: `menu`, `navbar`, `sidebar`, `breadcrumb`
- Website: `components.astro`, `templates/sidebar-dashboard.astro`

The wrapper class stays `.dropdown` — the issue only covers the attribute.

## Notes

Two stories use a `data-menu="#id"` attribute that nothing in the library reads, so those menus don't work today (`src/components/button/button.stories.ts:91`, `src/components/sidebar/sidebar.stories.ts:123`). Pre-existing and left alone here; the button one also isn't inside a `.dropdown` wrapper, so it needs more than an attribute swap.

## Testing

`npm run lint`, `npm run format:check`, and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)